### PR TITLE
Remove jQuery, fix light theme, drop FontAwesome & restyle (follow-up to #7)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,12 +25,6 @@
   <meta property="og:description" content="{{page.description}}" />
   <meta property="og:image" content="" />
 
-  <!-- jQuery -->
-  <script
-    src="https://code.jquery.com/jquery-3.7.1.min.js"
-    integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
-    crossorigin="anonymous"></script>
-
   <!-- mathjax -->
   <script>
     window.MathJax = {

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,6 @@
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico?">
   
   <!-- CSS -->
-  <script src="https://kit.fontawesome.com/bb01885591.js" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
 
   <!-- defualt -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -81,17 +81,31 @@
 </nav>
 
 <script>
-$(document).ready(function() {
-  // Check for click events on the navbar burger icon
-  $(".navbar-burger").click(function() {
-      // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
-      $(".navbar-burger").toggleClass("is-active");
-      $(".navbar-menu").toggleClass("is-active");
+document.addEventListener('DOMContentLoaded', function () {
+  // Toggle the mobile navbar menu (Bulma burger)
+  document.querySelectorAll('.navbar-burger').forEach(function (burger) {
+    burger.addEventListener('click', function () {
+      var target = document.getElementById(burger.dataset.target);
+      burger.classList.toggle('is-active');
+      if (target) target.classList.toggle('is-active');
+    });
   });
 
-  $('#site-search').on('click', function(e) {
-      var text = $($(this).siblings()[0]).val();
-      window.open('https://www.google.co.kr/search?q=site:blog.seotory.com+' + encodeURIComponent(text), '_blank');
-    });
+  // Site-scoped Google search
+  var searchBtn = document.getElementById('site-search');
+  if (searchBtn) {
+    var input = searchBtn.closest('.field.has-addons').querySelector('input');
+    var runSearch = function () {
+      var text = (input && input.value ? input.value : '').trim();
+      if (!text) return;
+      window.open('https://www.google.com/search?q=site:blog.seotory.com+' + encodeURIComponent(text), '_blank');
+    };
+    searchBtn.addEventListener('click', runSearch);
+    if (input) {
+      input.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') runSearch();
+      });
+    }
+  }
 });
 </script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
     <div class="navbar-brand">
       <a class="navbar-item" href="/">
         <span class="icon">
-          <i class="fas fa-home"></i>
+          {% include icon.html name="home" %}
         </span>
         <span>SEOTORY</span>
         <!-- <img src="https://bulma.io/images/bulma-logo.png" alt="Bulma: a modern CSS framework based on Flexbox" width="112" height="28"> -->
@@ -66,7 +66,7 @@
               <div class="control">
                 <a id="site-search" class="button is-link is-small is-rounded">
                   <span class="icon">
-                    <i class="fas fa-search"></i>
+                    {% include icon.html name="search" %}
                   </span>
                   <span>Search</span>
                 </a>

--- a/_includes/icon.html
+++ b/_includes/icon.html
@@ -1,0 +1,11 @@
+{%- comment -%}
+Inline Lucide (https://lucide.dev) SVG icons — replaces the FontAwesome kit.
+Usage: {% include icon.html name="home" %}
+{%- endcomment -%}
+{%- assign n = include.name -%}
+<svg class="lucide" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+{%- if n == "home" -%}<path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 22V12h6v10"/>
+{%- elsif n == "search" -%}<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>
+{%- elsif n == "info" -%}<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>
+{%- endif -%}
+</svg>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
   {% include head.html %}
   <body>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -88,7 +88,7 @@ layout: default
       <div class="block">  
         <span class="icon-text has-text-link">
           <span class="icon">
-            <i class="fas fa-info-circle"></i>
+            {% include icon.html name="info" %}
           </span>
           <span>Tags : </span>
         </span>

--- a/_sass/_theme.scss
+++ b/_sass/_theme.scss
@@ -1,0 +1,77 @@
+// ── Modernized theme layer on top of Bulma 1.0 ──
+// main.css is loaded after the Bulma CDN stylesheet, so overriding the
+// --bulma-* custom properties here re-derives Bulma's own colors/radii.
+
+:root {
+  // Refined indigo accent (replaces Bulma's default blue link color).
+  // Bulma derives --bulma-link / -light / -invert from this h/s/l trio.
+  --bulma-link-h: 244deg;
+  --bulma-link-s: 55%;
+  --bulma-link-l: 55%;
+  --bulma-primary-h: 244deg;
+  --bulma-primary-s: 55%;
+  --bulma-primary-l: 55%;
+
+  // Softer, larger corner radii for a more current look.
+  --bulma-radius-small: 0.5rem;
+  --bulma-radius: 0.7rem;
+  --bulma-radius-large: 1rem;
+
+  // Slightly cooler neutral scheme + near-white page so white cards lift.
+  --bulma-scheme-h: 220;
+  --bulma-scheme-s: 18%;
+  --bulma-body-background-color: hsl(220, 24%, 99%);
+}
+
+body {
+  line-height: 1.75;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+// Tighter, more modern headings.
+.title,
+h1, h2, h3 {
+  letter-spacing: -0.02em;
+}
+
+// Cards: hairline border + layered shadow + gentle hover lift.
+.box {
+  border: 1px solid hsl(220, 16%, 91%);
+  border-radius: var(--bulma-radius-large);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04),
+              0 10px 24px -14px rgba(15, 23, 42, 0.15);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.box:hover {
+  transform: translateY(-2px);
+  border-color: hsl(244, 40%, 85%);
+  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.05),
+              0 18px 36px -16px rgba(30, 27, 75, 0.22);
+}
+
+// Post-list titles: neutral by default, accent on hover (cleaner index).
+.box .title a {
+  color: inherit;
+  transition: color 0.15s ease;
+}
+.box .title a:hover {
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-l));
+}
+
+// Navbar: airy header with a subtle divider.
+.navbar.is-transparent {
+  border-bottom: 1px solid hsl(220, 16%, 92%);
+}
+
+// Softer tags/labels.
+.tag {
+  border-radius: 0.5rem;
+  font-weight: 500;
+}
+
+// Inline Lucide SVGs sit inside Bulma's .icon boxes — size them to match.
+.icon svg {
+  width: 1.15em;
+  height: 1.15em;
+}

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ layout: default
             {% if post.categories %}
             <span class="tag is-link is-normal is-light">
               <span class="icon">
-                <i class="fas fa-info-circle"></i>
+                {% include icon.html name="info" %}
               </span>
               <span>{{ post.categories }}</span>
             </span>

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -41,5 +41,6 @@ $code-line-height:   1.3;
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
     "base",
-    "font"
+    "font",
+    "theme"
 ;


### PR DESCRIPTION
## Why

PR #7 was merged while the branch only contained the first commit (library/CI
updates), so the three follow-up commits below never reached `master`. This PR
brings them in.

**Important:** #7 shipped the Bulma 0.9 → 1.0 upgrade *without* the light-theme
pin, so on `master` the site now auto-switches to dark mode for visitors whose
OS is in dark mode. Commit `2031285` here fixes that — this should be merged
before the next deploy.

## Changes (3 commits)

- **`c3db8ce` Remove jQuery, replace with vanilla JS** — jQuery was only used
  for the navbar burger + site search; rewritten with vanilla JS. Also fixes a
  latent bug where the old search read the wrong element and searched for
  `undefined`; adds Enter-to-search.
- **`2031285` Force light theme** — `<html data-theme="light">` restores the
  original white background regardless of the visitor's OS dark-mode setting
  (Bulma 1.0 added automatic `prefers-color-scheme` dark mode).
- **`d93a71d` Drop FontAwesome for inline SVG icons; modernize Bulma styling** —
  replace the FontAwesome JS kit (loaded for 3 icons) with inline Lucide SVGs
  via `_includes/icon.html`; add a `_sass/_theme.scss` restyle layer (indigo
  accent, rounded cards w/ soft shadow, tighter type) on top of Bulma 1.0.

## Verification

All verified locally with a real Ruby build + in-browser:
- `jekyll build`/`serve` return 200 across home, posts, pagination, categories, feed
- light theme holds white background even under a forced dark OS scheme
- navbar burger + search work; `window.jQuery`/`$` undefined; 0 FontAwesome leftovers
- no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)