### PR TITLE
Shrink oversized tag icons

### DIFF
--- a/_sass/_theme.scss
+++ b/_sass/_theme.scss
@@ -75,3 +75,14 @@ h1, h2, h3 {
   width: 1.15em;
   height: 1.15em;
 }
+
+// Inside a tag the .icon box is a fixed 1.5rem, which dwarfs the 12px tag
+// text — shrink the box and glyph so the icon reads at the text's size.
+.tag .icon {
+  width: 1em;
+  height: 1em;
+}
+.tag .icon svg {
+  width: 0.95em;
+  height: 0.95em;
+}


### PR DESCRIPTION
Category-tag info icon looked too big: Bulma's `.icon` box is a fixed 1.5rem next to 12px tag text. Constrain `.tag .icon` and its SVG to ~1em so the icon matches the text size. Verified in-browser.

Clean re-do of #9 (which conflicted due to squash-merge history divergence); please close #9 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)