### PR TITLE
Pin Node 22 in Astro deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Build with Astro
         uses: withastro/action@v3
+        with:
+          # Astro 7 requires Node >= 22.12; the action defaults to Node 20.
+          node-version: 22
         # Uses npm + the repo's package-lock.json; outputs ./dist
   deploy:
     needs: build


### PR DESCRIPTION
The first Pages deploy failed because withastro/action defaults to Node 20 but Astro 7 requires Node >= 22.12. Pass `node-version: 22`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)