### PR TITLE
Fix invisible code block background

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -24,6 +24,13 @@ pre.astro-code {
   tab-size: 4;
   overflow-x: auto;
 }
+// Shiki (github-light) sets an inline white background, which vanishes against
+// the near-white page. Override it with GitHub's code-block grey + a hairline
+// so the block reads as a distinct block. (!important beats Shiki's inline style.)
+pre.astro-code {
+  background-color: #f6f8fa !important;
+  border: 1px solid var(--bulma-border-weak);
+}
 .content :not(pre) > code {
   font-size: 0.9em;
 }


### PR DESCRIPTION
Shiki's inline white background made code blocks vanish against the near-white page. Override with GitHub's #f6f8fa + hairline border. 🤖 Generated with [Claude Code](https://claude.com/claude-code)