### PR TITLE
Add Google Analytics 4

### DIFF
--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -1,0 +1,22 @@
+---
+import { GA4_MEASUREMENT_ID } from '../consts';
+// Only load in production builds, so local dev traffic never hits the property.
+const enabled = import.meta.env.PROD && GA4_MEASUREMENT_ID;
+// Google's canonical gtag snippet, emitted verbatim so `gtag` stays global and
+// stays callable for events later (define:vars would scope it to an IIFE).
+const snippet = `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA4_MEASUREMENT_ID}');`;
+---
+{
+  enabled && (
+    <>
+      <script
+        async
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}
+      />
+      <script is:inline set:html={snippet} />
+    </>
+  )
+}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -8,6 +8,9 @@ export const SITE_URL = 'https://blog.seotory.com';
 // Google AdSense.
 export const ADSENSE_CLIENT = 'ca-pub-1634875166425349';
 
+// Google Analytics 4 measurement ID (stream: seotory blog - GA4).
+export const GA4_MEASUREMENT_ID = 'G-6S4LG3QJ26';
+
 // Posts per page.
 export const PAGE_SIZE = 10;
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import { SITE_TITLE, SITE_DESCRIPTION, SITE_URL, ADSENSE_CLIENT } from '../consts';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import Analytics from '../components/Analytics.astro';
 import '../styles/global.scss';
 
 interface Props {
@@ -55,6 +56,8 @@ const canonical = new URL(Astro.url.pathname, SITE_URL).href;
         />
       )
     }
+
+    <Analytics />
 
     <meta name="generator" content={Astro.generator} />
   </head>


### PR DESCRIPTION
The old UA property stopped collecting in 2023 and wasn't carried over in the migration, so the blog currently has no analytics. Wires up the GA4 stream for blog.seotory.com (`G-6S4LG3QJ26`, stream "seotory blog - GA4").

- New `Analytics.astro` emits Google's canonical gtag snippet verbatim (via `set:html`) so `gtag` stays **global** and callable for events later — `define:vars` would scope it inside an IIFE.
- Injected from `BaseLayout`'s `<head>`, **production builds only** (`import.meta.env.PROD`), so local dev traffic never hits the property.
- Measurement ID sits in `consts.ts` beside the AdSense client ID.

Verified in the production build: loader + snippet present on home and post pages, matching Google's official form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)