### PR TITLE
Use Pretendard so Korean and Latin share one typeface

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,6 +25,17 @@ const canonical = new URL(Astro.url.pathname, SITE_URL).href;
     <meta name="description" content={pageDesc} />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
 
+    <!-- Pretendard (CDN). The dynamic-subset build splits the (large) Korean
+         range into ~90 unicode-range slices, so a page only downloads the
+         glyphs it actually uses. Ships font-display: swap. -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
+    />
+
     <!-- Bulma (CDN) -->
     <link
       rel="stylesheet"

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -37,6 +37,15 @@ pre.astro-code {
 // rules that hardcode values are marked "custom" (Bulma exposes no variable).
 
 :root {
+  // Type — Bulma's default stack is Latin-only (Inter, SF Pro, …), so Korean
+  // fell through to whatever the OS picked and mixed badly with the Latin.
+  // Pretendard covers Latin + Korean in one family (Inter-compatible metrics).
+  // The tail is the fallback chain if the webfont never loads.
+  --bulma-family-primary: 'Pretendard Variable', Pretendard, -apple-system,
+    BlinkMacSystemFont, system-ui, 'Apple SD Gothic Neo', 'Noto Sans KR',
+    'Malgun Gothic', Roboto, 'Helvetica Neue', sans-serif;
+  --bulma-family-secondary: var(--bulma-family-primary);
+
   // Accent — Bulma derives --bulma-link / -primary and their shades from these.
   --bulma-link-h: 244deg;
   --bulma-link-s: 55%;


### PR DESCRIPTION
Bulma's default family stack is Latin-only (Inter, SF Pro, Segoe UI, …), so **Korean text fell past every entry to the generic `sans-serif`** and rendered in whatever font the visitor's OS picked — Apple SD Gothic Neo on macOS, Malgun Gothic on Windows. On a mostly-Korean blog that meant Latin and Hangul rendered in two different faces with mismatched weight/metrics, and every visitor saw something different. (This predates the Astro migration — the old Jekyll site defined NanumBarunGothic but never applied it, so it had the same gap.)

**Pretendard** covers both scripts in one family with Inter-compatible Latin metrics, so the Latin keeps its current look while Hangul stops falling back.

- Loads the **dynamic-subset variable build** from jsDelivr — splits the Korean range into ~90 `unicode-range` slices so a page only fetches the glyphs it uses; ships `font-display: swap`.
- Applied via Bulma's own `--bulma-family-primary` variable (framework-idiomatic), with a system-font fallback chain if the webfont never loads.
- Code blocks keep Bulma's mono stack.

**Verified locally**: only `Pretendard Variable` loads, `body` resolves to it, and Hangul measures differently from the `sans-serif` fallback (136.5px vs 155.9px) — confirming it no longer falls back to the OS font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)