### PR TITLE
Keep the floating dropdown treatment to desktop only

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -124,17 +124,24 @@ h1, h2, h3 {
 
 // Category dropdown — framework radius/shadow; inset padding + rounded items
 // (pill hover) and the pull-up are custom shape choices.
-.navbar-dropdown {
-  border-radius: var(--bulma-navbar-dropdown-radius);
-  border: 1px solid var(--bulma-border);
-  box-shadow: var(--bulma-navbar-dropdown-boxed-shadow);
-  padding: 0.4rem;      // custom
-  margin-top: -0.4rem;  // custom
-}
-.navbar-dropdown .navbar-item {
-  padding: 0.45rem 0.9rem; // custom
-  line-height: 1.4;
-  border-radius: var(--bulma-radius);
+//
+// Desktop only: below Bulma's $desktop breakpoint the navbar collapses and the
+// dropdown expands inline inside the burger menu (position: static). The
+// floating-box treatment must not follow it there, or it renders as a
+// bordered, shadowed box overlapping its own parent row.
+@media screen and (min-width: 1024px) {
+  .navbar-dropdown {
+    border-radius: var(--bulma-navbar-dropdown-radius);
+    border: 1px solid var(--bulma-border);
+    box-shadow: var(--bulma-navbar-dropdown-boxed-shadow);
+    padding: 0.4rem;      // custom
+    margin-top: -0.4rem;  // custom
+  }
+  .navbar-dropdown .navbar-item {
+    padding: 0.45rem 0.9rem; // custom
+    line-height: 1.4;
+    border-radius: var(--bulma-radius);
+  }
 }
 
 // Navbar wordmark spacing + optical nudge (custom).


### PR DESCRIPTION
Below Bulma's 1024px breakpoint the navbar collapses and the category dropdown expands **inline** inside the burger menu (`position: static`). The custom floating-box styling had **no media query**, so on mobile the dropdown still got a 1px border, a shadow, a 16px radius and the `-0.4rem` pull-up — rendering as a boxed panel overlapping its own "Dev" row.

Scopes those rules (and the inset item padding / pill radius) to `min-width: 1024px` so mobile falls back to Bulma's native inline menu.

**Verified at 375px**: border `0px none`, shadow `none`, radius `0px`, margin-top `0px`, items back to Bulma's `8px 24px` rows.
**Verified at 1280px**: floating box unchanged (border 1px, radius 16px, pull-up -6.4px, pill radius 11.2px, `position: absolute`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)