### PR TITLE
Prose rhythm, inline code, and a slimmer search field

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -81,14 +81,14 @@ const categoryNav = CATEGORY_NAV.filter((n) => n.use);
         type="search"
         name="q"
         placeholder="블로그 내 검색"
-        class="h-10 w-52 rounded-l-lg border border-r-0 border-accent-200 bg-white px-3 text-sm outline-none placeholder:text-ink-soft/60 focus:border-accent-500"
+        class="h-8 w-52 rounded-l-md border border-r-0 border-accent-200 bg-white px-2.5 text-[0.8125rem] outline-none placeholder:text-ink-soft/60 focus:border-accent-500"
       />
       <button
         type="submit"
-        class="flex h-10 items-center rounded-r-lg bg-accent-600 px-3 text-white hover:bg-accent-700"
+        class="flex h-8 items-center rounded-r-md bg-accent-600 px-2.5 text-white hover:bg-accent-700"
         aria-label="검색"
       >
-        <Icon name="search" class="size-4" />
+        <Icon name="search" class="size-3.5" />
       </button>
     </form>
 
@@ -133,14 +133,14 @@ const categoryNav = CATEGORY_NAV.filter((n) => n.use);
         type="search"
         name="q"
         placeholder="블로그 내 검색"
-        class="h-10 min-w-0 flex-1 rounded-l-lg border border-r-0 border-accent-200 px-3 text-sm outline-none focus:border-accent-500"
+        class="h-8 min-w-0 flex-1 rounded-l-md border border-r-0 border-accent-200 px-2.5 text-[0.8125rem] outline-none focus:border-accent-500"
       />
       <button
         type="submit"
-        class="rounded-r-lg bg-accent-600 px-3 text-white"
+        class="flex h-8 items-center rounded-r-md bg-accent-600 px-2.5 text-white"
         aria-label="검색"
       >
-        <Icon name="search" class="size-4" />
+        <Icon name="search" class="size-3.5" />
       </button>
     </form>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -85,7 +85,7 @@ const categoryNav = CATEGORY_NAV.filter((n) => n.use);
       />
       <button
         type="submit"
-        class="flex h-8 items-center rounded-r-md bg-accent-600 px-2.5 text-white hover:bg-accent-700"
+        class="flex h-8 items-center rounded-r-md border border-l-0 border-accent-200 bg-accent-50 px-2.5 text-accent-700 hover:bg-accent-100"
         aria-label="검색"
       >
         <Icon name="search" class="size-3.5" />
@@ -137,7 +137,7 @@ const categoryNav = CATEGORY_NAV.filter((n) => n.use);
       />
       <button
         type="submit"
-        class="flex h-8 items-center rounded-r-md bg-accent-600 px-2.5 text-white"
+        class="flex h-8 items-center rounded-r-md border border-l-0 border-accent-200 bg-accent-50 px-2.5 text-accent-700 hover:bg-accent-100"
         aria-label="검색"
       >
         <Icon name="search" class="size-3.5" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -84,6 +84,22 @@
     margin-top: 0.75em;
     margin-bottom: 0.75em;
   }
+
+  /* Typography decorates inline <code> with literal backticks via ::before /
+     ::after. The markdown is fine — `foo` already parses to <code>foo</code> —
+     so the backticks are pure noise on screen. Drop them and mark inline code
+     with a chip instead, which is what the backticks were standing in for. */
+  :where(code)::before,
+  :where(code)::after {
+    content: none;
+  }
+  :where(:not(pre) > code) {
+    background-color: var(--color-accent-50);
+    color: var(--color-accent-700);
+    padding: 0.15em 0.4em;
+    border-radius: 0.35em;
+    font-weight: 500;
+  }
 }
 
 @layer components {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,6 +65,25 @@
 .prose.prose-blog {
   --tw-prose-pre-bg: #f6f8fa;
   --tw-prose-pre-code: #24292e;
+
+  /* These posts use loose markdown lists (blank lines between items), so every
+     item wraps its text in a <p> and takes the full 1.25em paragraph margin —
+     each one-line item ended up 48px tall and the list read as a stack of
+     separate paragraphs. Tighten the item rhythm so a list holds together.
+     (0,2,0) again, to outrank the plugin's own (0,1,0) rules.) */
+  :where(li) {
+    margin-top: 0.25em;
+    margin-bottom: 0.25em;
+  }
+  :where(li > p) {
+    margin-top: 0.25em;
+    margin-bottom: 0.25em;
+  }
+  /* A code block inside a list item shouldn't shove the item apart either. */
+  :where(li) :where(pre) {
+    margin-top: 0.75em;
+    margin-bottom: 0.75em;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
These posts use **loose** markdown lists (blank lines between items), so every item wraps its text in a `<p>` and picks up the full `1.25em` paragraph margin. A one-line item ended up **48px tall with 20px between items** — a list read as a stack of separate paragraphs rather than one block.

| | Before | After |
|---|---|---|
| Gap between items | 20px | **4px** |
| One-line item height | 48px | **32px** |
| Paragraph spacing | 20px | 20px (untouched) |

Also stops a code block inside a list item from shoving the item apart. Paragraph spacing between actual paragraphs is left alone, so prose still breaks where it should.

Needs `.prose.prose-blog` (0,2,0) to outrank the plugin's own (0,1,0) rules — same reason as the code-block colour fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)