### PR TITLE
Give in-prose h1 section headings a top margin

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -108,6 +108,17 @@
   :where(strong) :where(code) {
     font-weight: inherit;
   }
+
+  /* Typography zeroes h1's top margin because it assumes h1 is the document
+     title and thus the first element. Here the title lives in the layout
+     header and the body uses `#` for section headings, so every section h1
+     rendered flush against the paragraph above it while the `##` subsections
+     kept their 2em. Give h1 a top margin slightly larger than h2's so the
+     heading hierarchy reads top-down (h1 > h2 > h3). The plugin's own
+     `:first-child { margin-top: 0 }` still protects the very top of the post. */
+  :where(h1) {
+    margin-top: 1.6em;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
본문 `#` 섹션 제목이 윗 문단에 바짝 붙던 문제 수정입니다.

## 원인
`@tailwindcss/typography`는 `h1`을 **문서 제목(첫 요소)**으로 가정해 `margin-top: 0`을 줍니다. 이 블로그는 제목을 레이아웃 헤더에 두고 본문에선 `#`을 섹션 제목으로 쓰므로, 모든 `#`(h1) 섹션이 위 여백 0이 되고 `##`(h2)만 2em을 받아 **위계가 뒤집혀** 보였습니다 (더 큰 제목이 더 작은 제목보다 여백이 없음).

## 수정
`.prose.prose-blog`에서 h1 `margin-top: 1.6em` 지정 → 절대 여백 57.6px로 h2(48px)보다 살짝 크게 두어 `h1 > h2 > h3` 순으로 정렬. 플러그인의 `:first-child { margin-top: 0 }`이 글 최상단은 계속 보호하므로 맨 위엔 불필요한 여백이 생기지 않습니다.

## 검증
- h1 mt 57.6px, h2 mt 48px, 최상단 문단 mt 0px (브라우저 계산값)
- 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)