### PR TITLE
Trim the About page: drop the title and connect, log the astro move

### DIFF
--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -3,15 +3,9 @@ layout: ../layouts/PageLayout.astro
 title: About
 ---
 
-## 서토리 (seotory)
-
 어느덧 10년차...
 
 ## blog history
 
 - 2016년 3월 18일 blog 이전 (tistory -> jekyll)
-
-## connect
-
-- https://blog.seotory.com
-- seotory437@gmail.com
+- 2026년 7월 blog 이전 (jekyll -> astro)


### PR DESCRIPTION
About 페이지 정리입니다.

- `## 서토리 (seotory)` 타이틀 삭제
- `## connect` 섹션(블로그 URL·이메일) 삭제
- `blog history`에 `2026년 7월 blog 이전 (jekyll -> astro)` 추가 (기존 tistory -> jekyll 항목과 동일 포맷)

날짜는 월 단위(2026년 7월)로 뒀습니다 — 마이그레이션이 며칠에 걸쳐 진행돼 특정 일자를 박기 애매해서입니다. 원하시면 특정 날짜로 바꾸거나 마이그레이션 글로 링크 걸 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)