### PR TITLE
About: call the blog moves migrations, not "이전"

### DIFF
--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -7,5 +7,5 @@ title: About
 
 ## blog history
 
-- 2016년 3월 18일 blog 이전 (tistory -> jekyll)
-- 2026년 7월 blog 이전 (jekyll -> astro)
+- 2016년 3월 18일 blog 마이그레이션 (tistory -> jekyll)
+- 2026년 7월 blog 마이그레이션 (jekyll -> astro)


### PR DESCRIPTION
\`blog history\` 두 항목의 "이전"을 "마이그레이션"으로 변경. "이전"이 移轉/以前로 애매해서 명확하게 통일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)